### PR TITLE
Fix partial matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BioCroField
-Version: 0.1.0
+Version: 0.1.1
 Title: Tools for BioCro Field Data
 Description: A collection of tools for processing field data related to BioCro
     crop growth simulations.

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,18 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# BioCroField VERSION 0.1.1
+
+- A bug related to partial name matching for partitioning components was
+  detected and fixed. In short, if a value of `leaf` mass was not supplied but
+  a value of `leaf_litter` _was_ supplied, the leaf litter mass would be used by
+  `process` when calculating LMA and other related properties, leading to
+  errors. Now, the internal code does not use partial name matching, and the
+  user is able to supply a different name for the leaf tissue component if it
+  does not have the standard name of `leaf`.
+- PRs related to creating this version:
+  - https://github.com/biocro/BioCroField/pull/2
+
 # BioCroField VERSION 0.1.0
 
 - This is the first version of BioCroField. At this point, the package is in a

--- a/R/add_seed_biomass.R
+++ b/R/add_seed_biomass.R
@@ -158,15 +158,16 @@ add_seed_biomass <- function(
 
     # Reset the crop name, variety, and location, which we can safely assume to
     # be the same across the entire data frame
-    initial_biomass$crop <- biomass_df$crop[1]
-    initial_biomass$variety <- biomass_df$variety[1]
-    initial_biomass$location <- biomass_df$location[1]
+    initial_biomass[['crop']] <- biomass_df[1, 'crop']
+    initial_biomass[['variety']] <- biomass_df[1, 'variety']
+    initial_biomass[['location']] <- biomass_df[1, 'location']
 
     # Specify the time
-    initial_biomass$year <- year
-    initial_biomass$doy <- doy
-    initial_biomass$hour <- hour
-    initial_biomass$time <- initial_biomass$doy + initial_biomass$hour / 24.0
+    initial_biomass[['year']] <- year
+    initial_biomass[['doy']] <- doy
+    initial_biomass[['hour']] <- hour
+    initial_biomass[['time']] <-
+        initial_biomass[['doy']] + initial_biomass[['hour']] / 24.0
 
     # Reset certain columns to zero; there is no leaf area when the plant is a
     # seed, so also make sure to set LAI to zero
@@ -175,11 +176,11 @@ add_seed_biomass <- function(
     }
 
     # Set the population, which was specified when calling this function
-    initial_biomass$population <- planting_density
+    initial_biomass[['population']] <- planting_density
 
     # Get the total initial biomass and store it in the new row
     total_initial_biomass <- seed_mass * planting_density * 2.47e-6
-    initial_biomass$initial_seed <- total_initial_biomass
+    initial_biomass[['initial_seed']] <- total_initial_biomass
 
     # Set some column values as fractions of the initial seed mass
     for (comp in names(component_fractions)) {

--- a/R/biomass_table.R
+++ b/R/biomass_table.R
@@ -30,14 +30,14 @@ biomass_table.harvest_point <- function(..., zero_when_missing = character()) {
     # Get the names of all the plant components that we have measurements for
     all_components <- unique(unlist(lapply(
         x,
-        function(hpp) {names(hpp$all_components_biocro)}
+        function(hpp) {names(hpp[['all_components_biocro']])}
     )))
 
     # Get the names of all the additional arguments that were supplied when the
     # harvest_point objects were created
     additional_arguments <- unique(unlist(lapply(
         x,
-        function(hpp) {names(hpp$additional_arguments)}
+        function(hpp) {names(hpp[['additional_arguments']])}
     )))
 
     # Specify all the column names for the data table
@@ -72,13 +72,13 @@ biomass_table.harvest_point <- function(..., zero_when_missing = character()) {
             }
         }
 
-        for (comp in names(hpp$all_components_biocro)) {
-            biomass[i, comp] <- hpp$all_components_biocro[[comp]]
+        for (comp in names(hpp[['all_components_biocro']])) {
+            biomass[i, comp] <- hpp[['all_components_biocro']][[comp]]
         }
 
         for (arg in additional_arguments) {
-            if (arg %in% names(hpp$additional_arguments)) {
-                biomass[i, arg] <- hpp$additional_arguments[[arg]]
+            if (arg %in% names(hpp[['additional_arguments']])) {
+                biomass[i, arg] <- hpp[['additional_arguments']][[arg]]
             }
         }
     }

--- a/R/harvest_point.R
+++ b/R/harvest_point.R
@@ -183,15 +183,15 @@ harvest_point <- function(
 
     # Do not allow a leaf with zero area but nonzero mass
     if (!is.na(partitioning_leaf_area) && partitioning_leaf_area == 0 &&
-        !is.null(partitioning_component_weights$leaf) &&
-            partitioning_component_weights$leaf > 0) {
+        !is.null(partitioning_component_weights[['leaf']]) &&
+            partitioning_component_weights[['leaf']] > 0) {
         stop("It is not possible for a leaf with zero area to have a nonzero mass")
     }
 
     # Do not allow a leaf with zero mass but nonzero area
     if (!is.na(partitioning_leaf_area) && partitioning_leaf_area > 0 &&
-        !is.null(partitioning_component_weights$leaf) &&
-            partitioning_component_weights$leaf == 0) {
+        !is.null(partitioning_component_weights[['leaf']]) &&
+            partitioning_component_weights[['leaf']] == 0) {
         stop("It is not possible for a leaf with zero mass to have a nonzero area")
     }
 

--- a/R/process.R
+++ b/R/process.R
@@ -32,11 +32,11 @@ process.harvest_point <- function(x) {
     # that we can handle incomplete information in the inputs.
 
     # The time (as specified in BioCro)
-    time <- x$doy + x$hour / 24.0
+    time <- x[['doy']] + x[['hour']] / 24.0
 
     # Above-ground biomass from the plants that were partitioned (in g)
-    partitioning_agb_weight <- if (length(x$agb_components) > 0) {
-        sum(as.numeric(x$partitioning_component_weights[x$agb_components]))
+    partitioning_agb_weight <- if (length(x[['agb_components']]) > 0) {
+        sum(as.numeric(x[['partitioning_component_weights']][x[['agb_components']]]))
     } else {
         NA
     }
@@ -44,22 +44,22 @@ process.harvest_point <- function(x) {
     # Compare above-ground biomass per plant among the plants used for
     # partitioning and the section of row used for above-ground biomass.
     agb_per_plant_partitioning <-
-        partitioning_agb_weight / x$partitioning_nplants
+        partitioning_agb_weight / x[['partitioning_nplants']]
 
-    agb_per_plant_row <- x$agb_weight / x$agb_nplants
+    agb_per_plant_row <- x[['agb_weight']] / x[['agb_nplants']]
 
     # Estimate the plant population (plants per acre) from the number of plants
     # collected for above-ground biomass measurements, using 1 acre = 4047 m^2
-    population <- x$agb_nplants / (x$agb_row_length * x$row_spacing) * 4047
+    population <- x[['agb_nplants']] / (x[['agb_row_length']] * x[['row_spacing']]) * 4047
 
     # Calculate the above-ground biomass per unit area (in Mg / ha), using
     # 1 g / m^2 = 1e-2 Mg / ha
-    agb_per_area <- x$agb_weight / (x$agb_row_length * x$row_spacing) * 1e-2
+    agb_per_area <- x[['agb_weight']] / (x[['agb_row_length']] * x[['row_spacing']]) * 1e-2
 
     # Relative component weights from plants that were partitioned, normalized
     # by the above-ground biomass from those plants
     relative_components <- lapply(
-        x$partitioning_component_weights,
+        x[['partitioning_component_weights']],
         function(pcw) {pcw / partitioning_agb_weight}
     ) # dimensionless from m / (m agb)
 
@@ -72,10 +72,10 @@ process.harvest_point <- function(x) {
     # Leaf mass per leaf area (in g / m^2). We should only calculate this if
     # there is a partitioned leaf mass and a partitioned leaf area; even in that
     # case, if the leaf area is not positive, we still should not calculate LMA.
-    LMA <- if(!is.null(x$partitioning_component_weights$leaf) && !is.na(x$partitioning_leaf_area)) {
-        if (x$partitioning_leaf_area > 0) {
-                x$partitioning_component_weights$leaf /
-                    x$partitioning_leaf_area * 1e4 # g / m^2
+    LMA <- if(!is.null(x[['partitioning_component_weights']][['leaf']]) && !is.na(x[['partitioning_leaf_area']])) {
+        if (x[['partitioning_leaf_area']] > 0) {
+                x[['partitioning_component_weights']][['leaf']] /
+                    x[['partitioning_leaf_area']] * 1e4 # g / m^2
         } else {
             NA
         }
@@ -87,9 +87,9 @@ process.harvest_point <- function(x) {
     # (g / m^2 ground) / (g / m^2 leaf). We should only calculate this if there
     # is a leaf mass per ground area and a partitioned leaf area; in that case,
     # LAI should be set to zero when the leaf area is zero.
-    LAI <- if(!is.null(components_biocro$leaf) && !is.na(x$partitioning_leaf_area)) {
-        if (x$partitioning_leaf_area > 0) {
-            components_biocro$leaf / LMA * 1e2
+    LAI <- if(!is.null(components_biocro[['leaf']]) && !is.na(x[['partitioning_leaf_area']])) {
+        if (x[['partitioning_leaf_area']] > 0) {
+            components_biocro[['leaf']] / LMA * 1e2
         } else {
             0.0
         }
@@ -102,8 +102,8 @@ process.harvest_point <- function(x) {
 
     # Biomass from litter trap in units typically used in BioCro
     trap_components_biocro <- lapply(
-        x$trap_component_weights,
-        function(tcw) {tcw / x$trap_area * 1e-2}
+        x[['trap_component_weights']],
+        function(tcw) {tcw / x[['trap_area']] * 1e-2}
     ) # Mg / ha
 
     # Combine all components

--- a/R/process.R
+++ b/R/process.R
@@ -1,4 +1,4 @@
-process <- function(x) {
+process <- function(x, ...) {
     UseMethod('process', x)
 }
 
@@ -26,7 +26,7 @@ process <- function(x) {
 # - 1 g / m^2 * (1 Mg / 1e6 g) * (1e4 m^2 / 1 ha) = 1e-2 Mg / ha
 # - 1 m^2 / g * (1e6 g / 1 Mg) * (1 ha / 1e4 m^2) = 1e2 ha / Mg
 # - 1 g / cm^2 * (100 cm / m)^2 = 1e4 g / m^2
-process.harvest_point <- function(x) {
+process.harvest_point <- function(x, leaf_name = 'leaf', ...) {
     # In this function, we won't do any type checking; we can assume that has
     # been addressed by `harvest_point`. Instead, the main goal is to make sure
     # that we can handle incomplete information in the inputs.
@@ -72,9 +72,9 @@ process.harvest_point <- function(x) {
     # Leaf mass per leaf area (in g / m^2). We should only calculate this if
     # there is a partitioned leaf mass and a partitioned leaf area; even in that
     # case, if the leaf area is not positive, we still should not calculate LMA.
-    LMA <- if(!is.null(x[['partitioning_component_weights']][['leaf']]) && !is.na(x[['partitioning_leaf_area']])) {
+    LMA <- if(!is.null(x[['partitioning_component_weights']][[leaf_name]]) && !is.na(x[['partitioning_leaf_area']])) {
         if (x[['partitioning_leaf_area']] > 0) {
-                x[['partitioning_component_weights']][['leaf']] /
+                x[['partitioning_component_weights']][[leaf_name]] /
                     x[['partitioning_leaf_area']] * 1e4 # g / m^2
         } else {
             NA
@@ -87,9 +87,9 @@ process.harvest_point <- function(x) {
     # (g / m^2 ground) / (g / m^2 leaf). We should only calculate this if there
     # is a leaf mass per ground area and a partitioned leaf area; in that case,
     # LAI should be set to zero when the leaf area is zero.
-    LAI <- if(!is.null(components_biocro[['leaf']]) && !is.na(x[['partitioning_leaf_area']])) {
+    LAI <- if(!is.null(components_biocro[[leaf_name]]) && !is.na(x[['partitioning_leaf_area']])) {
         if (x[['partitioning_leaf_area']] > 0) {
-            components_biocro[['leaf']] / LMA * 1e2
+            components_biocro[[leaf_name]] / LMA * 1e2
         } else {
             0.0
         }

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -11,13 +11,21 @@
 }
 
 \usage{
-  process(x)
+  process(x, \dots)
 
-  \method{process}{harvest_point}(x)
+  \method{process}{harvest_point}(x, leaf_name = 'leaf', \dots)
 }
 
 \arguments{
   \item{x}{A \code{\link{harvest_point}} object.}
+
+  \item{leaf_name}{
+    A string specifying the name of the leaf tissue to use when calculating the
+    leaf area index. Typically, the leaf mass is called \code{'leaf'}, but it
+    may sometimes have a similar name such as \code{'main_leaf'}.
+  }
+
+  \item{\dots}{Additional arguments (currently unused).}
 }
 
 \details{
@@ -160,6 +168,17 @@ hp <- harvest_point(
 hpp <- process(hp)
 
 str(hpp)
+
+# Example: Creating and processing a harvest point object that has `main_leaf`
+# rather than `leaf`.
+hp2 <- harvest_point(
+  partitioning_component_weights = list(main_leaf = 1),
+  partitioning_leaf_area = 2
+)
+
+hpp2 <- process(hp2)
+
+print(hpp2$LMA)
 }
 
 \concept{harvest_point}

--- a/tests/testthat/test-partial-matching.R
+++ b/tests/testthat/test-partial-matching.R
@@ -1,0 +1,14 @@
+# Partial matching when accessing list elements can cause problems. For example,
+# if values of `leaf_litter` but not `leaf` are supplied when creating a
+# `harvest_point` object, then a nonsensical value of `LMA` will be calculated
+# because `partitioning_component_weights$leaf_litter` will be a partial match
+# for the (unavailable) `partitioning_component_weights$leaf`.
+
+test_that("`leaf_litter` is not a partial match for `leaf`", {
+    expect_true(
+        is.na(process(harvest_point(
+            partitioning_component_weights = list(leaf_litter = 1),
+            partitioning_leaf_area = 2
+        ))$LMA)
+    )
+})

--- a/tests/testthat/test-partial-matching.R
+++ b/tests/testthat/test-partial-matching.R
@@ -12,3 +12,19 @@ test_that("`leaf_litter` is not a partial match for `leaf`", {
         ))$LMA)
     )
 })
+
+test_that("alternate leaf names can be provided", {
+    expect_equal(
+        process(
+            harvest_point(
+                partitioning_component_weights = list(main_leaf = 1),
+                partitioning_leaf_area = 2
+            ),
+            leaf_name = 'main_leaf'
+        )$LMA,
+        process(harvest_point(
+            partitioning_component_weights = list(leaf = 1),
+            partitioning_leaf_area = 2
+        ))$LMA
+    )
+})


### PR DESCRIPTION
This PR fixes a bug related to partial name matching for partitioning components.

In short, if a value of `leaf` mass was not supplied when creating a `harvest_point` object but a value of `leaf_litter` _was_ supplied, the leaf litter mass would be used by `process` when calculating LMA and other related properties. This behavior could lead to errors that may be difficult to notice.

In this PR, the internal code does not use partial name matching any more, and the user is able to supply a different name for the leaf tissue component if it does not have the standard name of `leaf`.